### PR TITLE
text utils: Do float division for word count in wpm calculations

### DIFF
--- a/src/text_utils.rs
+++ b/src/text_utils.rs
@@ -286,10 +286,10 @@ pub fn current_word(original: &str, typed_grapheme_count: usize) -> usize {
 }
 
 pub fn calculate_wpm(duration: Duration, typed: &str) -> f64 {
-    let minutes: f64 = duration.as_secs_f64() / 60.;
-    let words = typed.chars().count() / 5;
+    let minutes = duration.as_secs_f64() / 60.;
+    let words = typed.chars().count() as f64 / 5.;
 
-    words as f64 / minutes
+    words / minutes
 }
 
 pub fn calculate_accuracy(original: &str, typed: &str) -> f64 {


### PR DESCRIPTION
The word count is currently calculated with integer division. As a result, some precision is lost when the character count is not divisible by 5. This problem becomes very evident when doing a custom test with <5 characters, where the result will always be 0 wpm.

Before

https://github.com/user-attachments/assets/87ff4bad-5225-463c-8f54-a965fd5ae254

After


https://github.com/user-attachments/assets/35430e39-4ddd-478f-a961-aa0618b8bd19

