### PR TITLE
window: style dropdowns as flat properly

### DIFF
--- a/data/resources/style.css
+++ b/data/resources/style.css
@@ -18,11 +18,6 @@ KpResultsView .key-number {
   font-weight: 700;
 }
 
-.flat-dropdown > button:not(:checked):not(:hover) {
-  background: transparent;
-  box-shadow: none;
-}
-
 .header-bar-running .start,
 .header-bar-running .end,
 .header-bar-running.hide-controls:focus-within .start,

--- a/src/widgets/window.blp
+++ b/src/widgets/window.blp
@@ -35,18 +35,11 @@ template $KpWindow: Adw.ApplicationWindow {
 
                   DropDown session_type_dropdown {
                     tooltip-text: _("Session Type");
-                    styles [
-                      "flat-dropdown"
-                    ]
                   }
 
                   Stack secondary_config_stack {
                     DropDown duration_dropdown {
                       tooltip-text: _("Session Duration");
-
-                      styles [
-                        "flat-dropdown"
-                      ]
                     }
 
                     Button custom_button {

--- a/src/widgets/window.rs
+++ b/src/widgets/window.rs
@@ -168,6 +168,9 @@ mod imp {
                 self.obj().add_css_class("devel");
             }
 
+            self.session_type_dropdown.first_child().unwrap().add_css_class("flat");
+            self.duration_dropdown.first_child().unwrap().add_css_class("flat");
+
             self.load_settings();
             self.setup_session_config();
 

--- a/src/widgets/window.rs
+++ b/src/widgets/window.rs
@@ -168,6 +168,7 @@ mod imp {
                 self.obj().add_css_class("devel");
             }
 
+            // Workaround until dropdowns gain proper flat styling in libadwaita 2.0
             self.session_type_dropdown.first_child().unwrap().add_css_class("flat");
             self.duration_dropdown.first_child().unwrap().add_css_class("flat");
 


### PR DESCRIPTION
I meant to do this when you mentioned it on https://gitlab.gnome.org/GNOME/libadwaita/-/merge_requests/1163 but forgot about it :eyes: 

The problem with dropdowns and button styles is that GtkDropDown is a container that has a GtkToggleButton as its child. So when you add .flat to the DropDown, the style doesn't get applied to ToggleButton. Your workaround works but doesn't cover every single case `.flat` does on buttons (and won't inherit any future libadwaita changes automatically)

The one on the left is using the method in this PR while the one on the right uses `.flat-dropdown`. Notice the differences in the background color between the different button states

https://github.com/user-attachments/assets/edf4ea65-1688-4898-8791-a09f8ff0235f

This PR does the workaround mentioned in my libadwaita MR; it gets the first child (which is the ToggleButton) and adds the flat class to it