### PR TITLE
chore(deps): bump blueprint version to 0.16.0

### DIFF
--- a/build-aux/dev.bragefuglseth.Keypunch.Devel.json
+++ b/build-aux/dev.bragefuglseth.Keypunch.Devel.json
@@ -45,7 +45,7 @@
 	    {
 	      "type": "git",
 	      "url": "https://gitlab.gnome.org/jwestman/blueprint-compiler",
-	      "tag": "v0.14.0"
+	      "tag": "v0.16.0"
 	    }
 	  ]
 	},


### PR DESCRIPTION
The new version fixes a dependency issue that prevented Keypunch from being built.