### PR TITLE
build: Sync manifests

### DIFF
--- a/build-aux/dev.bragefuglseth.Keypunch.Devel.json
+++ b/build-aux/dev.bragefuglseth.Keypunch.Devel.json
@@ -6,7 +6,7 @@
     "sdk-extensions" : [
         "org.freedesktop.Sdk.Extension.rust-stable"
     ],
-    "command" : "keypunch-wrapper.sh",
+    "command" : "keypunch",
     "finish-args" : [
         "--share=network",
         "--share=ipc",
@@ -48,23 +48,6 @@
 	      "tag": "v0.16.0"
 	    }
 	  ]
-	},
-	{
-	    "name" : "keypunch-wrapper",
-	    "buildsystem" : "simple",
-	    "build-commands" : [
-	    	"install -Dm755 keypunch-wrapper.sh /app/bin/keypunch-wrapper.sh"
-	    ],
-	    "sources" : [
-	    	{
-            	    "type" : "script",
-            	    "dest-filename" : "keypunch-wrapper.sh",
-            	    "commands" : [
-            	    	"for i in {0..9}; do\ntest -S $XDG_RUNTIME_DIR/discord-ipc-$i || ln -sf {app/com.discordapp.Discord,$XDG_RUNTIME_DIR}/discord-ipc-$i;\ndone",
-            	    	"keypunch"
-            	    ]
-            	}
-	    ]
 	},
         {
             "name" : "keypunch",

--- a/build-aux/dev.bragefuglseth.Keypunch.DiscordAccess.json
+++ b/build-aux/dev.bragefuglseth.Keypunch.DiscordAccess.json
@@ -49,7 +49,7 @@
 	    {
 	      "type": "git",
 	      "url": "https://gitlab.gnome.org/jwestman/blueprint-compiler",
-	      "tag": "v0.14.0"
+	      "tag": "v0.16.0"
 	    }
 	  ]
 	},


### PR DESCRIPTION
Removes an unnecessary wrapper script from the devel manifest (since the Discord library we use already checks for an IPC socket in the proper Flatpak location), and bumps blueprint to v0.16.0 in the Discord access manifest.