### PR TITLE
feat: Accept non-breaking spaces as subsitutes for regular ones

### DIFF
--- a/src/text_utils.rs
+++ b/src/text_utils.rs
@@ -40,6 +40,8 @@ const ALIASES: &'static [(&'static str, &'static str)] = &[
     ("’", "'"),               // Typoographic apostrophe
     ("\u{00A0}", "\u{0020}"), // Non-breaking spaces made typable as regular ones
     ("\u{202F}", "\u{0020}"),
+    ("\u{0020}", "\u{00A0}"), // Vice versa
+    ("\u{0020}", "\u{202F}"),
 ];
 
 // The largest grapheme count of any current alias, manually kept track of for performance reasons.


### PR DESCRIPTION
Mostly relevant for French typists. Closes #108.