### PR TITLE
fix: correct action name for test cancellation shortcut

### DIFF
--- a/data/resources/gtk/help-overlay.ui
+++ b/data/resources/gtk/help-overlay.ui
@@ -18,7 +18,7 @@
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="title" translatable="yes" context="shortcut window">Cancel Session</property>
-                <property name="action-name">win.cancel-session</property>
+                <property name="action-name">win.cancel-test</property>
               </object>
             </child>
             <child>


### PR DESCRIPTION
Forgot to update this one when renaming the action.