### PR TITLE
docs: Post-Circle update

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,34 +1,6 @@
 # Contributing
 
-Thanks for your interest in contributing to Keypunch! Here are some useful things to know:
-
-## Issues and suggestions
-
-Bug reports and feature requests are welcome. However, please keep the following in mind:
-
-- Flatpak is the only officially supported packaging format
-- The app has a [conservative approach to preferences](https://ometer.com/preferences.html); things should ideally be good enough out of the box
-- Before making a change and opening a pull request, make sure to discuss it in the issue tracker first, to make sure that the change will be accepted
-- This project follows the [GNOME Code of Conduct](https://conduct.gnome.org)
-
-## Building
-
-Use the Flatpak version of [GNOME Builder](https://apps.gnome.org/Builder) to build and run the project from source: 
-
-1. Open Builder and press the "Clone Repository…" button
-2. Paste a link to the repository in the "Repository URL" field:
-
-   ```
-   https://github.com/bragefuglseth/keypunch
-   ```
-
-3. Press the "Clone repository…" button
-4. Press confirm if asked about automatic installation of any dependencies, and wait for them to download
-5. Press the play button in the header bar
-
-## Translating
-
-Keypunch does not have any external translation infrastructure as of now, but a slot on Weblate will be applied for as soon as the project meets the requirements. Until then, please submit translations as regular pull requests. Translation work happens in the `po` directory.
+Thanks for your interest in contributing to Keypunch! Most of the information you're looking for can likely be found in Keypunch's [contribution guide](https://welcome.gnome.org/app/Keypunch) on the Welcome to GNOME website. This document contains information specific to Keypunch that cannot be found in said contribution guide.
 
 ## Adding a Language
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 [![Available on Flathub](https://img.shields.io/flathub/downloads/dev.bragefuglseth.Keypunch?logo=flathub&labelColor=77767b&color=4a90d9)](https://flathub.org/apps/dev.bragefuglseth.Keypunch)
 [![Chat on Matrix](https://img.shields.io/badge/chat-%23keypunch%3Agnome.org-mediumorchid?style=flat&logo=matrix)](https://matrix.to/#/#keypunch:gnome.org)
+[![Proudly part of GNOME Circle](https://circle.gnome.org/assets/button/badge.svg)](https://circle.gnome.org)
 [![Please do not theme this app](https://stopthemingmy.app/badge.svg)](https://stopthemingmy.app)
 
 ![screenshot](/data/screenshots/2-ready.png)
@@ -22,9 +23,25 @@ Keypunch is available on Flathub.
 
 [<img width="240" alt="Download on Flathub" src="https://flathub.org/api/badge?svg&locale=en"/>](https://flathub.org/apps/dev.bragefuglseth.Keypunch)
 
+## GNOME Circle
+
+Keypunch is proudly part of GNOME Circle, an initiative that champions the
+great software that is available for the GNOME platform. For more information,
+visit the GNOME Circle website.
+
+[<img width="240" src="https://circle.gnome.org/assets/button/circle-button-fullcolor.svg">](https://circle.gnome.org)
+
 ## Contributing
 
-Contributions are welcome! Refer to [CONTRIBUTING.md](CONTRIBUTING.md) for more. This project follows the [GNOME Code of Conduct](https://conduct.gnome.org).
+## Contributing
+
+Contributions are extremely welcome. To see how you can help with issue reporting, development, and translations, consult Keypunch's [contribution guide](https://welcome.gnome.org/app/Keypunch). For project-specific documentation, such as how to add a new text language, see [CONTRIBUTING.md](CONTRIBUTING.md).
+
+Please take this into consideration as well:
+
+- This project follows the [GNOME Code of Conduct](https://conduct.gnome.org).
+- Only Flatpak is officially supported.
+- If you want to contribute major changes, please discuss them beforehand to verify that they are suitable for the project.
 
 ## Name
 

--- a/data/dev.bragefuglseth.Keypunch.metainfo.xml.in.in
+++ b/data/dev.bragefuglseth.Keypunch.metainfo.xml.in.in
@@ -30,6 +30,9 @@
     <p>
       Get ready to accelerate your typing!
     </p>
+    <p>
+      Keypunch is proudly part of GNOME Circle, an initiative that champions the great software that is available for the GNOME platform. For more information, visit the GNOME Circle website.
+    </p>
   </description>
   <screenshots>
     <screenshot type="default">
@@ -57,10 +60,10 @@
     <color type="primary" scheme_preference="light">#c879ff</color>
     <color type="primary" scheme_preference="dark">#9a00d3</color>
   </branding>
-  <url type="homepage">https://github.com/bragefuglseth/keypunch</url>
+  <url type="homepage">https://apps.gnome.org/Keypunch</url>
   <url type="bugtracker">https://github.com/bragefuglseth/keypunch/issues</url>
-  <url type="contribute">https://github.com/bragefuglseth/keypunch/blob/main/CONTRIBUTING.md</url>
-  <url type="translate">https://github.com/bragefuglseth/keypunch/blob/main/CONTRIBUTING.md#translating</url>
+  <url type="contribute">https://welcome.gnome.org/app/Keypunch</url>
+  <url type="translate">https://github.com/bragefuglseth/keypunch/tree/main/po</url>
   <url type="vcs-browser">https://github.com/bragefuglseth/keypunch</url>
   <url type="contact">https://matrix.to/#/#keypunch:gnome.org</url>
   <update_contact>bragefuglseth_AT_gnome.org</update_contact>

--- a/keypunch.doap
+++ b/keypunch.doap
@@ -6,7 +6,7 @@
 
   <name xml:lang="en">Keypunch</name>
   <shortdesc xml:lang="en">Practice your typing skills</shortdesc>
-  <homepage rdf:resource="https://github.com/bragefuglseth/keypunch" />
+  <homepage rdf:resource="https://apps.gnome.org/Keypunch" />
   <bug-database rdf:resource="https://github.com/bragefuglseth/keypunch/issues" />
 
   <programming-language>Rust</programming-language>


### PR DESCRIPTION
Since Keypunch is now part of GNOME Circle, update a few links and add some text to reflect that.