### PR TITLE
fix: handle backspace correctly

### DIFF
--- a/src/widgets/text_view.rs
+++ b/src/widgets/text_view.rs
@@ -38,6 +38,13 @@ use unicode_segmentation::UnicodeSegmentation;
 
 const LINE_HEIGHT: i32 = 50;
 
+#[derive(PartialEq)]
+enum TextChange {
+    Addition,
+    Removal,
+    Replacement,
+}
+
 mod imp {
     use super::*;
 
@@ -177,7 +184,7 @@ mod imp {
             self.compare_and_update_colors();
         }
 
-        pub(super) fn typed_text_changed(&self) {
+        pub(super) fn typed_text_changed(&self, change: TextChange) {
             let input_context = self.input_context.borrow();
             let (preedit, _, _) = input_context.as_ref().unwrap().preedit_string();
 
@@ -187,17 +194,21 @@ mod imp {
                 preedit.as_str().graphemes(true).count(),
             );
 
-            let last_grapheme_state = comparison
-                .iter()
-                .last()
-                .map(|(state, _, _, _)| *state)
-                .unwrap_or(GraphemeState::Unfinished);
+            if change == TextChange::Addition {
+                let last_grapheme_state = comparison
+                   .iter()
+                    .last()
+                    .map(|(state, _, _, _)| *state)
+                    .unwrap_or(GraphemeState::Unfinished);
 
-            let correct = last_grapheme_state != GraphemeState::Mistake;
-
-            let keystroke = (Instant::now(), correct);
-
-            self.keystrokes.borrow_mut().push(keystroke);
+                let correct = last_grapheme_state != GraphemeState::Mistake;
+                let keystroke = (Instant::now(), correct);
+                self.keystrokes.borrow_mut().push(keystroke);
+            } else if change == TextChange::Removal {
+                // If text is removed, it's always a "correct" stroke
+                let keystroke = (Instant::now(), true);
+                self.keystrokes.borrow_mut().push(keystroke);
+            }
 
             self.update_colors(&comparison);
             self.update_caret_position(!self.running.get());
@@ -233,7 +244,7 @@ impl KpTextView {
 
     pub fn set_typed_text(&self, text: &str) {
         *self.imp().typed_text.borrow_mut() = text.to_string();
-        self.imp().typed_text_changed();
+        self.imp().typed_text_changed(TextChange::Replacement);
         self.imp().input_context.borrow().as_ref().unwrap().reset();
     }
 

--- a/src/widgets/text_view/input.rs
+++ b/src/widgets/text_view/input.rs
@@ -59,7 +59,7 @@ impl imp::KpTextView {
                     }
 
                     *imp.previous_preedit.borrow_mut() = preedit.to_string();
-                    imp.typed_text_changed();
+                    imp.typed_text_changed(TextChange::Addition);
                 }
             }
         ));
@@ -121,6 +121,8 @@ impl imp::KpTextView {
             #[upgrade_or]
             glib::signal::Propagation::Proceed,
             move |controller, key, _, modifier| {
+                if imp.typed_text.borrow().is_empty() { return glib::signal::Propagation::Proceed; }
+
                 let obj = imp.obj();
 
                 match (obj.accepts_input(), key) {
@@ -161,13 +163,13 @@ impl imp::KpTextView {
             self.typed_text.borrow_mut().push_str(&letter);
         }
 
-        self.typed_text_changed();
+        self.typed_text_changed(TextChange::Addition);
     }
 
     fn pop_typed_text(&self, graphemes: usize) {
         pop_grapheme_in_place(&mut self.typed_text.borrow_mut(), graphemes);
 
-        self.typed_text_changed();
+        self.typed_text_changed(TextChange::Removal);
     }
 
     fn pop_typed_text_word(&self) {
@@ -176,6 +178,6 @@ impl imp::KpTextView {
             &mut self.typed_text.borrow_mut(),
         );
 
-        self.typed_text_changed();
+        self.typed_text_changed(TextChange::Removal);
     }
 }


### PR DESCRIPTION
Previously, backspacing would count as an error internally if the previous character after that was incorrectly typed. This resolves that by supplying the typed_text_changed function with information about how the text has changed, so it can make a judgement on whether to count it as correct or not based on that.