### PR TITLE
fix: fall back to English if language code is unknown

### DIFF
--- a/src/typing_test_utils.rs
+++ b/src/typing_test_utils.rs
@@ -56,7 +56,8 @@ impl TestConfig {
     pub fn from_settings(settings: &gio::Settings) -> Self {
         match settings.string("session-type").as_str() {
             difficulty_string @ ("Simple" | "Advanced") => TestConfig::Generated {
-                language: Language::from_str(&settings.string("text-language")).unwrap(),
+                language: Language::from_str(&settings.string("text-language"))
+                    .unwrap_or(Language::English),
                 difficulty: GeneratedTestDifficulty::from_str(&difficulty_string).unwrap(),
                 duration: TestDuration::from_str(&settings.string("session-duration")).unwrap(),
             },

--- a/src/widgets/text_language_dialog.rs
+++ b/src/widgets/text_language_dialog.rs
@@ -259,7 +259,8 @@ impl KpTextLanguageDialog {
             .property("settings", settings.clone())
             .build();
 
-        let current = Language::from_str(&settings.string("text-language")).unwrap();
+        let current =
+            Language::from_str(&settings.string("text-language")).unwrap_or(Language::English);
 
         let recent: Vec<Language> = settings
             .value("recent-languages")


### PR DESCRIPTION
Resolves the problem in #137, but we should find out what caused the unknown language code in the first place.