### PR TITLE
fix: focus button not shown

### DIFF
--- a/src/widgets/window/focus.rs
+++ b/src/widgets/window/focus.rs
@@ -63,7 +63,7 @@ impl imp::KpWindow {
                                 move || {
                                     if !imp.text_view_focused()
                                         && imp.obj().visible_dialog().is_none()
-                                        && imp.main_stack.visible_child_name().unwrap() == "session"
+                                        && imp.main_stack.visible_child_name().unwrap() == "test"
                                     {
                                         bottom_stack.set_visible_child(&focus_button);
                                         text_view.add_css_class("unfocused");


### PR DESCRIPTION
The focus button was not shown due to the callback still checking for the "session" view although that has been renamed to "test".

Closes #147 