### PR TITLE
feat: initial implementation for caps lock warning

### DIFF
--- a/src/widgets/window.blp
+++ b/src/widgets/window.blp
@@ -234,12 +234,29 @@ template $KpWindow: Adw.ApplicationWindow {
             transition-duration: 200;
             halign: center;
 
-            Label just_start_typing {
-              label: _("Just Start Typing");
+            Box typing_indicator {
+              spacing: 10;
+              orientation: vertical;
 
-              styles [
-                "dim-label"
-              ]
+              [top]
+              Label caps_lock {
+                label: _("Caps Lock is on");
+
+                visible: false;
+
+                styles [
+                  "warning"
+                ]
+              }
+
+              [bottom]
+              Label just_start_typing {
+                label: _("Just Start Typing");
+
+                styles [
+                  "dim-label",
+                ]
+              }
             }
 
             Button focus_button {

--- a/src/widgets/window.rs
+++ b/src/widgets/window.rs
@@ -66,7 +66,7 @@ mod imp {
         #[template_child]
         pub bottom_stack_empty: TemplateChild<adw::Bin>,
         #[template_child]
-        pub just_start_typing: TemplateChild<gtk::Label>,
+        pub typing_indicator: TemplateChild<gtk::Box>,
         #[template_child]
         pub focus_button: TemplateChild<gtk::Button>,
         #[template_child]

--- a/src/widgets/window/focus.rs
+++ b/src/widgets/window/focus.rs
@@ -37,7 +37,7 @@ impl imp::KpWindow {
             move |_| {
                 let text_view = imp.text_view.get();
                 let bottom_stack_empty = imp.bottom_stack_empty.get();
-                let just_start_typing = imp.just_start_typing.get();
+                let just_start_typing = imp.typing_indicator.get();
                 let focus_button = imp.focus_button.get();
                 let bottom_stack = imp.bottom_stack.get();
 


### PR DESCRIPTION
Simple caps lock warning

It does not show currently up while typing as I thought that the user would be acknowledging it before starting to type and it would be a distraction

Also, I think that the warning should be in bold text, but I haven't seen any GNOME apps use anything besides the "warning" style class.