### PR TITLE
Run on FreeBSD

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -22,7 +22,12 @@ endif
 run_command('cp', 'dev.bragefuglseth.Keypunch.metainfo.xml.in.in', 'dev.bragefuglseth.Keypunch.metainfo.xml.in', check: true)
 
 # Sed is used as a poor man's `configure_file` here because we need access to it in the src dir
-sed = find_program('sed', required: true)
+
+if build_machine.system() in ['freebsd', 'netbsd', 'openbsd', 'dragonfly']
+  meson.override_find_program('sed', find_program('gsed'))
+endif
+
+sed = find_program('gsed', 'sed', required: true) # We should probably still prefer gsed if it exists
 run_command(sed, '-i', 's/@app-id@/' + app_id + '/g', 'dev.bragefuglseth.Keypunch.metainfo.xml.in', check: true)
 
 appstream_file = i18n.merge_file(


### PR DESCRIPTION
BSD systems don't use GNU sed by default, but may have `gsed` installed. The command used doesn't work with the default sed, so now we'll prefer it if running on a BSD system or if it's available at all (because there are other cases where this might happen, like maybe Alpine Linux).

I tested on FreeBSD, but not on other BSD's.