### PR TITLE
Add Numbers-only typing mode

### DIFF
--- a/data/dev.bragefuglseth.Keypunch.gschema.xml
+++ b/data/dev.bragefuglseth.Keypunch.gschema.xml
@@ -3,7 +3,8 @@
   <enum id="dev.bragefuglseth.Keypunch.SessionType">
     <value nick="Simple" value="0" />
     <value nick="Advanced" value="1" />
-    <value nick="Custom" value="2" />
+    <value nick="Numbers" value="2" />
+    <value nick="Custom" value="3" />
   </enum>
 
   <enum id="dev.bragefuglseth.Keypunch.SessionDuration">

--- a/src/discord_rpc.rs
+++ b/src/discord_rpc.rs
@@ -78,6 +78,11 @@ impl Default for RpcWrapper {
                             duration,
                             ..
                         } => format!("Advanced, {}", duration.english_string()),
+                        TestConfig::Generated {
+                            difficulty: GeneratedTestDifficulty::Numbers,
+                            duration,
+                            ..
+                        } => format!("Numbers, {}", duration.english_string()),
                     };
 
                     stored_activity = Activity::new()

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -2,7 +2,7 @@ use gtk::gio;
 use gtk::prelude::*;
 
 // Must match their corresponding gschema enumss
-pub const SESSION_TYPE_VALUES: &'static [&str] = &["Simple", "Advanced", "Custom"];
+pub const SESSION_TYPE_VALUES: &'static [&str] = &["Simple", "Advanced", "Numbers", "Custom"];
 pub const SESSION_DURATION_VALUES: &'static [&str] = &["Sec15", "Sec30", "Min1", "Min5", "Min10"];
 
 pub fn bind_dropdown_selected(

--- a/src/text_generation.rs
+++ b/src/text_generation.rs
@@ -472,3 +472,21 @@ fn random_number_weighted(numerals: &Numerals, rng: &mut ThreadRng) -> String {
 
     s
 }
+
+// Generates a string of random numbers (0-9999) separated by spaces.
+// Uses Western Arabic numerals only.
+pub fn numbers_only() -> String {
+    let mut rng = rand::thread_rng();
+    let numerals = WESTERN_ARABIC_NUMERALS;
+
+    let mut generated = Vec::new();
+    let mut grapheme_count = 0;
+
+    while grapheme_count < CHUNK_GRAPHEME_COUNT {
+        let number = random_number_weighted(numerals, &mut rng);
+        grapheme_count += number.graphemes(true).count() + 1; // +1 for space
+        generated.push(number);
+    }
+
+    generated.join(" ")
+}

--- a/src/typing_test_utils.rs
+++ b/src/typing_test_utils.rs
@@ -30,6 +30,7 @@ use strum_macros::{Display as EnumDisplay, EnumIter, EnumString};
 pub enum GeneratedTestDifficulty {
     Simple,
     Advanced,
+    Numbers,
 }
 
 impl GeneratedTestDifficulty {
@@ -37,6 +38,7 @@ impl GeneratedTestDifficulty {
         match s {
             "simple" => Some(GeneratedTestDifficulty::Simple),
             "advanced" => Some(GeneratedTestDifficulty::Advanced),
+            "numbers" => Some(GeneratedTestDifficulty::Numbers),
             _ => None,
         }
     }
@@ -55,7 +57,7 @@ pub enum TestConfig {
 impl TestConfig {
     pub fn from_settings(settings: &gio::Settings) -> Self {
         match settings.string("session-type").as_str() {
-            difficulty_string @ ("Simple" | "Advanced") => TestConfig::Generated {
+            difficulty_string @ ("Simple" | "Advanced" | "Numbers") => TestConfig::Generated {
                 language: Language::from_str(&settings.string("text-language"))
                     .unwrap_or(Language::English),
                 difficulty: GeneratedTestDifficulty::from_str(&difficulty_string).unwrap(),

--- a/src/widgets/results_view.rs
+++ b/src/widgets/results_view.rs
@@ -172,6 +172,7 @@ impl KpResultsView {
             TestConfig::Generated { difficulty, .. } => match difficulty {
                 GeneratedTestDifficulty::Simple => gettext("Simple"),
                 GeneratedTestDifficulty::Advanced => gettext("Advanced"),
+                GeneratedTestDifficulty::Numbers => gettext("Numbers"),
             },
         };
 

--- a/src/widgets/window.blp
+++ b/src/widgets/window.blp
@@ -166,7 +166,7 @@ template $KpWindow: Adw.ApplicationWindow {
                 DropDown test_type_dropdown {
                   tooltip-text: _("Test Type");
                   model: StringList {
-                    strings [_("Simple"), _("Advanced"), _("Custom")]
+                    strings [_("Simple"), _("Advanced"), _("Numbers"), _("Custom")]
                   };
                 }
 

--- a/src/widgets/window/typing_test.rs
+++ b/src/widgets/window/typing_test.rs
@@ -432,6 +432,7 @@ impl imp::KpWindow {
             } => match difficulty {
                 GeneratedTestDifficulty::Simple => text_generation::simple(language),
                 GeneratedTestDifficulty::Advanced => text_generation::advanced(language),
+                GeneratedTestDifficulty::Numbers => text_generation::numbers_only(),
             },
             TestConfig::Finite => process_custom_text(&settings.string("custom-text")),
         };
@@ -548,6 +549,7 @@ impl imp::KpWindow {
         let new_chunk = match difficulty {
             GeneratedTestDifficulty::Simple => text_generation::simple(language),
             GeneratedTestDifficulty::Advanced => text_generation::advanced(language),
+            GeneratedTestDifficulty::Numbers => text_generation::numbers_only(),
         };
         self.text_view.push_original_text(&new_chunk);
     }


### PR DESCRIPTION
  Adds a new 'Numbers' test type that generates random integers (0-9999)
  separated by spaces for practicing numeric typing.
  in my testing using gnome builder it worked without any issues 
  PS: Iam fairly new to opensource contributions any and all guidance will be greatly appreciated
  Addresses #162