### PR TITLE
Fix pt_advanced word list accentuation

### DIFF
--- a/data/word_lists/pt_advanced.txt
+++ b/data/word_lists/pt_advanced.txt
@@ -200,8 +200,9 @@ abrir
 quase
 realizar
 é
+à
 são
-hà
+há
 às
 dê
 vô


### PR DESCRIPTION
Quick fix in the word list pt_advanced, reported in issue #46 (https://github.com/bragefuglseth/keypunch/issues/46#issuecomment-4300810242).

After discussion, the fix was to separate the incorrect word "hà" into two words: "há" and "à".