### PR TITLE
feat: Add Numbers & Symbols text option

### DIFF
--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -6,6 +6,7 @@ src/widgets/custom_text_dialog.blp
 src/widgets/results_view.blp
 src/widgets/results_view.rs
 src/widgets/text_language_dialog.blp
+src/widgets/text_language_dialog.rs
 src/widgets/text_view.blp
 src/widgets/window.blp
 src/widgets/window.rs

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -2,11 +2,11 @@ data/dev.bragefuglseth.Keypunch.desktop.in.in
 data/dev.bragefuglseth.Keypunch.metainfo.xml.in.in
 data/dev.bragefuglseth.Keypunch.gschema.xml
 data/resources/shortcuts-dialog.ui
+src/text_generation.rs
 src/widgets/custom_text_dialog.blp
 src/widgets/results_view.blp
 src/widgets/results_view.rs
 src/widgets/text_language_dialog.blp
-src/widgets/text_language_dialog.rs
 src/widgets/text_view.blp
 src/widgets/window.blp
 src/widgets/window.rs

--- a/src/text_generation.rs
+++ b/src/text_generation.rs
@@ -26,7 +26,7 @@ use unicode_segmentation::UnicodeSegmentation;
 static EMBEDDED_WORD_LIST_DIR: Dir = include_dir!("$CARGO_MANIFEST_DIR/data/word_lists");
 pub const CHUNK_GRAPHEME_COUNT: usize = 400;
 
-// All languages here MUST have a corresponding file in data/word_lists/{lang_code}.txt
+// All word-list languages here MUST have a corresponding file in data/word_lists/{lang_code}.txt
 #[derive(Clone, Copy, Default, EnumDisplay, EnumString, EnumIter, EnumMessage, PartialEq)]
 pub enum Language {
     #[strum(message = "العربية", to_string = "ar")]
@@ -48,6 +48,8 @@ pub enum Language {
     #[default]
     #[strum(message = "English", to_string = "en")]
     English,
+    #[strum(message = "Numbers & Symbols", to_string = "numbers")]
+    Numbers,
     #[strum(message = "Eesti", to_string = "et")]
     Estonian,
     #[strum(message = "Suomi", to_string = "fi")]
@@ -164,6 +166,13 @@ const BANGLA_NUMERALS: &'static Numerals = &["০", "১", "২", "৩", "৪", 
 pub fn simple(language: Language) -> String {
     match language {
         // Add special cases here if relevant
+        Language::Numbers => {
+            let mut rng = thread_rng();
+            random_numbers(&mut rng)
+                .into_iter()
+                .map(|s| s + " ")
+                .collect()
+        }
         _ => simple_generic(&language.to_string(), " "),
     }
 }
@@ -172,6 +181,14 @@ pub fn simple(language: Language) -> String {
 pub fn advanced(language: Language) -> String {
     match language {
         // Add special cases here if relevant
+        Language::Numbers => {
+            let mut rng = thread_rng();
+            let mut generated = random_numbers(&mut rng);
+
+            insert_random_punctuation(&mut generated, GENERIC_PUNCTUATION, &mut rng);
+
+            generated.into_iter().map(|s| s + " ").collect()
+        }
         // Arabic has its own set of punctuation and a couple of words with vowel markers
         Language::Arabic => advanced_generic(
             "ar_advanced",
@@ -370,11 +387,23 @@ fn advanced_generic(
         }
     }
 
+    insert_random_punctuation(&mut generated, punctuations, &mut rng);
+
+    generated.into_iter().map(|s| s + spacing).collect()
+}
+
+fn insert_random_punctuation(
+    generated: &mut [String],
+    punctuations: &[Punctuation],
+    rng: &mut ThreadRng,
+) {
+    let len = generated.len();
+
     // Sample from the entire text except for the last word, since that gets punctuation
     // further down in the function
-    for i in sample(&mut rng, len - 2, len / 4) {
+    for i in sample(rng, len - 2, len / 4) {
         if let Some(word) = generated.get_mut(i) {
-            if let Ok(punctuation) = punctuations.choose_weighted(&mut rng, |p| p.weight) {
+            if let Ok(punctuation) = punctuations.choose_weighted(rng, |p| p.weight) {
                 *word = insert_punctuation(&word, *punctuation);
 
                 if punctuation.ends_sentence {
@@ -387,17 +416,11 @@ fn advanced_generic(
     }
 
     // Insert random "sentence ending" punctuation on last word
-    if let Some(end_punctuation) = punctuations
-        .iter()
-        .filter(|p| p.ends_sentence)
-        .choose(&mut rng)
-    {
+    if let Some(end_punctuation) = punctuations.iter().filter(|p| p.ends_sentence).choose(rng) {
         if let Some(word) = generated.get_mut(len - 1) {
             *word = insert_punctuation(&word, *end_punctuation);
         }
     }
-
-    generated.into_iter().map(|s| s + spacing).collect()
 }
 
 fn uppercase_first_letter(s: &str) -> String {
@@ -446,6 +469,15 @@ fn random_words_from_lang_code(lang_code: &str, rng: &mut ThreadRng) -> Vec<Stri
     generated
 }
 
+fn random_numbers(rng: &mut ThreadRng) -> Vec<String> {
+    let mut generated: Vec<String> = Vec::new();
+    while generated.iter().flat_map(|s| s.graphemes(true)).count() < CHUNK_GRAPHEME_COUNT {
+        generated.push(random_number_weighted(WESTERN_ARABIC_NUMERALS, rng));
+    }
+
+    generated
+}
+
 fn insert_punctuation(word: &str, punctuation: Punctuation) -> String {
     match (punctuation.prefix, punctuation.suffix) {
         (Some(pre), Some(suf)) => format!("{pre}{word}{suf}"),
@@ -473,4 +505,28 @@ fn random_number_weighted(numerals: &Numerals, rng: &mut ThreadRng) -> String {
     }
 
     s
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use super::*;
+
+    #[test]
+    fn numbers_language_generates_numeric_text() {
+        let simple_numbers = simple(Language::Numbers);
+        assert!(!simple_numbers.is_empty());
+        assert!(simple_numbers
+            .chars()
+            .all(|c| c.is_ascii_digit() || c == ' '));
+
+        let advanced_numbers = advanced(Language::Numbers);
+        assert!(!advanced_numbers.is_empty());
+
+        assert!(matches!(
+            Language::from_str("numbers"),
+            Ok(Language::Numbers)
+        ));
+    }
 }

--- a/src/text_generation.rs
+++ b/src/text_generation.rs
@@ -17,6 +17,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+use gettextrs::gettext;
 use include_dir::{include_dir, Dir};
 use rand::prelude::*;
 use rand::seq::index::sample;
@@ -110,6 +111,23 @@ pub enum Language {
     Vietnamese,
     #[strum(message = "فارسی", to_string = "fa")]
     Persian,
+}
+
+impl Language {
+    // Localized name shown in the UI. Real languages use their autonym (which
+    // should not be translated), while pseudo-languages like Numbers are app
+    // UI copy and go through gettext.
+    pub fn display_name(self) -> String {
+        use strum::EnumMessage;
+
+        match self {
+            Language::Numbers => gettext("Numbers & Symbols"),
+            _ => self
+                .get_message()
+                .expect("all languages have names set")
+                .to_string(),
+        }
+    }
 }
 
 #[derive(Clone, Copy)]

--- a/src/widgets/results_view.rs
+++ b/src/widgets/results_view.rs
@@ -181,8 +181,7 @@ impl KpResultsView {
             TestConfig::Finite => imp.language_box.set_visible(false),
             TestConfig::Generated { language, .. } => {
                 imp.language_box.set_visible(true);
-                imp.language_label
-                    .set_label(&language.get_message().unwrap());
+                imp.language_label.set_label(&language.display_name());
             }
         }
     }

--- a/src/widgets/text_language_dialog.rs
+++ b/src/widgets/text_language_dialog.rs
@@ -20,12 +20,11 @@
 use crate::text_generation::Language;
 use adw::prelude::*;
 use adw::subclass::prelude::*;
-use gettextrs::gettext;
 use gtk::{gio, glib};
 use std::cell::RefCell;
 use std::iter::once;
 use std::str::FromStr;
-use strum::{EnumMessage, IntoEnumIterator};
+use strum::IntoEnumIterator;
 use unidecode::unidecode;
 
 const LANGUAGE_REQUEST_URL: &'static str = "https://github.com/bragefuglseth/keypunch/issues/new?assignees=&labels=new+language&projects=&template=language_request.yaml&title=%5BLanguage+Request%5D%3A+";
@@ -155,8 +154,7 @@ mod imp {
                 .collect();
 
             // Sort alphabetically
-            languages_without_recent_or_current
-                .sort_by_key(|language| language_display_name(*language));
+            languages_without_recent_or_current.sort_by_key(|language| language.display_name());
 
             for language in languages_without_recent_or_current {
                 let row = language_row(language);
@@ -175,12 +173,12 @@ mod imp {
                 let normalized_query = unidecode(&query.to_lowercase());
                 let mut results: Vec<Language> = Language::iter()
                     .filter(|language| {
-                        unidecode(&language_display_name(*language).to_lowercase())
+                        unidecode(&language.display_name().to_lowercase())
                             .contains(&normalized_query)
                     })
                     .collect();
 
-                results.sort_by_key(|language| language_display_name(*language).to_lowercase());
+                results.sort_by_key(|language| language.display_name().to_lowercase());
 
                 if results.is_empty() {
                     self.no_results_lock_height(false);
@@ -266,19 +264,9 @@ impl KpTextLanguageDialog {
     }
 }
 
-fn language_display_name(language: Language) -> String {
-    match language {
-        Language::Numbers => gettext("Numbers & Symbols"),
-        _ => language
-            .get_message()
-            .expect("all languages have names set")
-            .to_string(),
-    }
-}
-
 fn language_row(language: Language) -> adw::ActionRow {
     let row = adw::ActionRow::new();
-    row.set_title(&language_display_name(language));
+    row.set_title(&language.display_name());
 
     let check_button = gtk::CheckButton::builder()
         .action_name("app.text-language")

--- a/src/widgets/text_language_dialog.rs
+++ b/src/widgets/text_language_dialog.rs
@@ -20,6 +20,7 @@
 use crate::text_generation::Language;
 use adw::prelude::*;
 use adw::subclass::prelude::*;
+use gettextrs::gettext;
 use gtk::{gio, glib};
 use std::cell::RefCell;
 use std::iter::once;
@@ -154,11 +155,8 @@ mod imp {
                 .collect();
 
             // Sort alphabetically
-            languages_without_recent_or_current.sort_by_key(|language| {
-                language
-                    .get_message()
-                    .expect("all languages have names set")
-            });
+            languages_without_recent_or_current
+                .sort_by_key(|language| language_display_name(*language));
 
             for language in languages_without_recent_or_current {
                 let row = language_row(language);
@@ -177,22 +175,12 @@ mod imp {
                 let normalized_query = unidecode(&query.to_lowercase());
                 let mut results: Vec<Language> = Language::iter()
                     .filter(|language| {
-                        unidecode(
-                            &language
-                                .get_message()
-                                .expect("all languages have names set")
-                                .to_lowercase(),
-                        )
-                        .contains(&normalized_query)
+                        unidecode(&language_display_name(*language).to_lowercase())
+                            .contains(&normalized_query)
                     })
                     .collect();
 
-                results.sort_by_key(|language| {
-                    language
-                        .get_message()
-                        .expect("all languages have names set")
-                        .to_lowercase()
-                });
+                results.sort_by_key(|language| language_display_name(*language).to_lowercase());
 
                 if results.is_empty() {
                     self.no_results_lock_height(false);
@@ -278,9 +266,19 @@ impl KpTextLanguageDialog {
     }
 }
 
+fn language_display_name(language: Language) -> String {
+    match language {
+        Language::Numbers => gettext("Numbers & Symbols"),
+        _ => language
+            .get_message()
+            .expect("all languages have names set")
+            .to_string(),
+    }
+}
+
 fn language_row(language: Language) -> adw::ActionRow {
     let row = adw::ActionRow::new();
-    row.set_title(&language.get_message().unwrap());
+    row.set_title(&language_display_name(language));
 
     let check_button = gtk::CheckButton::builder()
         .action_name("app.text-language")


### PR DESCRIPTION
## Summary

Adds a "Numbers & Symbols" entry to the text language dialog so you can practice typing numbers. Selecting it generates random numbers instead of words (simple mode), with numbers interspersed with punctuation in advanced mode, reusing the existing text generation pipeline.

## Why this matters

Issue #162 asked for a way to practice numeric typing. An earlier attempt (#164) added this as a separate entry in the test-type dropdown and was closed, with the request to instead put it in the text language dialog "as an option alongside the existing languages." This change follows that direction: the option shows up in the language list and round-trips through the existing `text-language` setting, and the generation lives next to the other languages in `src/text_generation.rs`. The label is routed through a shared `Language::display_name()` so it stays localizable and renders consistently in the dialog and on the results screen.

## Testing

- Added a unit test in `src/text_generation.rs` asserting simple mode is digits and spaces only, advanced mode is non-empty, and `Language::from_str("numbers")` parses back to the new variant. The text generation logic builds and the test passes in isolation (`cargo test -p keypunch text_generation`); the full app build needs system GTK libraries.
- `rustfmt --check` passes on the changed files.

Fixes #162
